### PR TITLE
Fix JWKS previous key id

### DIFF
--- a/idp/internal/providers/tokens/tokens.go
+++ b/idp/internal/providers/tokens/tokens.go
@@ -283,7 +283,7 @@ func NewTokens(
 	if accountKeysData.prevPubKey != nil {
 		jwks = append(jwks, utils.EncodeP256Jwk(
 			accountKeysData.prevPubKey.publicKey,
-			accessData.prevPubKey.kid,
+			accountKeysData.prevPubKey.kid,
 		))
 	}
 	if accessData.prevPubKey != nil {


### PR DESCRIPTION
## Summary
- fix incorrect KID when building JWKS list for previous account credentials key

## Testing
- `go test ./...` *(fails: `Forbidden` while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684e0a57de7c8320bd6be69ac93b5e3c